### PR TITLE
feat: switch to document style to include type definitions in the documentation

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -1,0 +1,19 @@
+## Goals
+
+The main objective is to create a more logic data structure, achieved by combining and grouping related resources together in a complex object.
+
+The structure of the module promotes reusability. It's intended to be a repeatable component, simplifying the process of building diverse workloads and platform accelerators consistently.
+
+A primary goal is to utilize keys and values in the object that correspond to the REST API's structure. This enables us to carry out iterations, increasing its practical value as time goes on.
+
+A last key goal is to separate logic from configuration in the module, thereby enhancing its scalability, ease of customization, and manageability.
+
+## Non-Goals
+
+These modules are not intended to be complete, ready-to-use solutions; they are designed as components for creating your own patterns.
+
+They are not tailored for a single use case but are meant to be versatile and applicable to a range of scenarios.
+
+Security standardization is applied at the pattern level, while the modules include default values based on best practices but do not enforce specific security standards.
+
+End-to-end testing is not conducted on these modules, as they are individual components and do not undergo the extensive testing reserved for complete patterns or solutions.

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ test-parallel:
 	cd tests && go test -v -timeout 60m -run '^TestApplyAllParallel$$' -args $(TEST_ARGS) .
 
 docs:
-	@echo "Generating documentation for root and modules..."
-	terraform-docs markdown . --output-file README.md --output-mode inject --hide modules
+	@echo "Generating document-style documentation for root and modules..."
+	terraform-docs markdown document . --output-file README.md --output-mode inject --hide modules
 	for dir in modules/*; do \
 		if [ -d "$$dir" ]; then \
 			echo "Processing $$dir..."; \
-			terraform-docs markdown "$$dir" --output-file "$$dir/README.md" --output-mode inject --hide modules || echo "Skipped: $$dir"; \
+			terraform-docs markdown document "$$dir" --output-file "$$dir/README.md" --output-mode inject --hide modules || echo "Skipped: $$dir"; \
 		fi \
 	done
 

--- a/README.md
+++ b/README.md
@@ -2,26 +2,6 @@
 
 This terraform module simplifies the process of creating and managing subscriptions on azure with customizable options and features, offering a flexible and powerful solution for managing azure subscriptions through code.
 
-## Goals
-
-The main objective is to create a more logic data structure, achieved by combining and grouping related resources together in a complex object.
-
-The structure of the module promotes reusability. It's intended to be a repeatable component, simplifying the process of building diverse workloads and platform accelerators consistently.
-
-A primary goal is to utilize keys and values in the object that correspond to the REST API's structure. This enables us to carry out iterations, increasing its practical value as time goes on.
-
-A last key goal is to separate logic from configuration in the module, thereby enhancing its scalability, ease of customization, and manageability.
-
-## Non-Goals
-
-These modules are not intended to be complete, ready-to-use solutions; they are designed as components for creating your own patterns.
-
-They are not tailored for a single use case but are meant to be versatile and applicable to a range of scenarios.
-
-Security standardization is applied at the pattern level, while the modules include default values based on best practices but do not enforce specific security standards.
-
-End-to-end testing is not conducted on these modules, as they are individual components and do not undergo the extensive testing reserved for complete patterns or solutions.
-
 ## Features
 
 - offers support for the creation of MCA subscriptions and enrollment (EA) subscriptions.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Description: management group subscription associations
 Description: subscription(s) details
 <!-- END_TF_DOCS -->
 
+## Goals
+
+For more information, please see our [goals and non-goals](./GOALS.md).
+
 ## Testing
 
 For more information, please see our testing [guidelines](./TESTING.md)

--- a/README.md
+++ b/README.md
@@ -31,46 +31,131 @@ End-to-end testing is not conducted on these modules, as they are individual com
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.0)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
+The following providers are used by this module:
+
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (~> 4.0)
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [azurerm_management_group_subscription_association.subs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_subscription_association) | resource |
-| [azurerm_management_lock.lock](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
-| [azurerm_subscription.subs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subscription) | resource |
-| [azurerm_billing_enrollment_account_scope.enrollment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/billing_enrollment_account_scope) | data source |
-| [azurerm_billing_mca_account_scope.mca](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/billing_mca_account_scope) | data source |
-| [azurerm_billing_mpa_account_scope.mpa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/billing_mpa_account_scope) | data source |
-| [azurerm_management_group.group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/management_group) | data source |
+The following resources are used by this module:
 
-## Inputs
+- [azurerm_management_group_subscription_association.subs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_subscription_association) (resource)
+- [azurerm_management_lock.lock](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
+- [azurerm_subscription.subs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subscription) (resource)
+- [azurerm_billing_enrollment_account_scope.enrollment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/billing_enrollment_account_scope) (data source)
+- [azurerm_billing_mca_account_scope.mca](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/billing_mca_account_scope) (data source)
+- [azurerm_billing_mpa_account_scope.mpa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/billing_mpa_account_scope) (data source)
+- [azurerm_management_group.group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/management_group) (data source)
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_billing_enrollment_account"></a> [billing\_enrollment\_account](#input\_billing\_enrollment\_account) | billing enrollment account details | <pre>object({<br/>    billing_account_name    = string<br/>    enrollment_account_name = string<br/>  })</pre> | `null` | no |
-| <a name="input_billing_mca_account"></a> [billing\_mca\_account](#input\_billing\_mca\_account) | billing mca account details | <pre>object({<br/>    billing_account_name = string<br/>    billing_profile_name = string<br/>    invoice_section_name = string<br/>  })</pre> | `null` | no |
-| <a name="input_billing_mpa_account"></a> [billing\_mpa\_account](#input\_billing\_mpa\_account) | billing mpa account details | <pre>object({<br/>    billing_account_name = string<br/>    customer_name        = string<br/>  })</pre> | `null` | no |
-| <a name="input_subscriptions"></a> [subscriptions](#input\_subscriptions) | subscription details | <pre>map(object({<br/>    name                          = optional(string)<br/>    alias                         = optional(string)<br/>    billing_scope_id              = optional(string)<br/>    subscription_id               = optional(string)<br/>    workload                      = optional(string)<br/>    tags                          = optional(map(string))<br/>    management_group_name         = optional(string)<br/>    management_group_display_name = optional(string)<br/>    management_lock = optional(object({<br/>      name  = optional(string)<br/>      level = optional(string)<br/>      notes = optional(string)<br/>    }))<br/>  }))</pre> | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | tags to be added to the subscription(s) | `map(string)` | `{}` | no |
+## Required Inputs
+
+The following input variables are required:
+
+### <a name="input_subscriptions"></a> [subscriptions](#input\_subscriptions)
+
+Description: subscription details
+
+Type:
+
+```hcl
+map(object({
+    name                          = optional(string)
+    alias                         = optional(string)
+    billing_scope_id              = optional(string)
+    subscription_id               = optional(string)
+    workload                      = optional(string)
+    tags                          = optional(map(string))
+    management_group_name         = optional(string)
+    management_group_display_name = optional(string)
+    management_lock = optional(object({
+      name  = optional(string)
+      level = optional(string)
+      notes = optional(string)
+    }))
+  }))
+```
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_billing_enrollment_account"></a> [billing\_enrollment\_account](#input\_billing\_enrollment\_account)
+
+Description: billing enrollment account details
+
+Type:
+
+```hcl
+object({
+    billing_account_name    = string
+    enrollment_account_name = string
+  })
+```
+
+Default: `null`
+
+### <a name="input_billing_mca_account"></a> [billing\_mca\_account](#input\_billing\_mca\_account)
+
+Description: billing mca account details
+
+Type:
+
+```hcl
+object({
+    billing_account_name = string
+    billing_profile_name = string
+    invoice_section_name = string
+  })
+```
+
+Default: `null`
+
+### <a name="input_billing_mpa_account"></a> [billing\_mpa\_account](#input\_billing\_mpa\_account)
+
+Description: billing mpa account details
+
+Type:
+
+```hcl
+object({
+    billing_account_name = string
+    customer_name        = string
+  })
+```
+
+Default: `null`
+
+### <a name="input_tags"></a> [tags](#input\_tags)
+
+Description: tags to be added to the subscription(s)
+
+Type: `map(string)`
+
+Default: `{}`
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_management_group"></a> [management\_group](#output\_management\_group) | management group details |
-| <a name="output_management_group_subscription_associations"></a> [management\_group\_subscription\_associations](#output\_management\_group\_subscription\_associations) | management group subscription associations |
-| <a name="output_subscriptions"></a> [subscriptions](#output\_subscriptions) | subscription(s) details |
+The following outputs are exported:
+
+### <a name="output_management_group"></a> [management\_group](#output\_management\_group)
+
+Description: management group details
+
+### <a name="output_management_group_subscription_associations"></a> [management\_group\_subscription\_associations](#output\_management\_group\_subscription\_associations)
+
+Description: management group subscription associations
+
+### <a name="output_subscriptions"></a> [subscriptions](#output\_subscriptions)
+
+Description: subscription(s) details
 <!-- END_TF_DOCS -->
 
 ## Testing

--- a/examples/enrollment/README.md
+++ b/examples/enrollment/README.md
@@ -1,25 +1,3 @@
 # Default
 
 This example illustrates how to create a Enrollment subscription, a subscription with a Enterprise Agreement.
-
-## Types
-
-```hcl
-subscriptions = map(object({
-  name                          = string
-  alias                         = optional(string)
-  management_group_name         = optional(string)
-  management_group_display_name = optional(string)
-  billing_scope_id              = optional(string)
-  workload                      = optional(string, "Production")
-  tags                          = map(object)
-}))
-
-billing_mca_account = object({
-    billing_account_name = string  # billing account id
-    billing_profile_name = string  # billing profile id
-    invoice_section_name = string  # invoice section id
-  })
-```
-
-## Notes

--- a/examples/mca/README.md
+++ b/examples/mca/README.md
@@ -2,29 +2,9 @@
 
 This example illustrates how to create a MCA subscription, a subscription with a Microsoft Customer Agreement.
 
-## Types
-
-```hcl
-subscriptions = map(object({
-  name                          = string
-  alias                         = optional(string)
-  management_group_name         = optional(string)
-  management_group_display_name = optional(string)
-  billing_scope_id              = optional(string)
-  workload                      = optional(string, "Production")
-  tags                          = map(object)
-}))
-
-billing_mca_account = object({
-    billing_account_name = string  # billing account id
-    billing_profile_name = string  # billing profile id
-    invoice_section_name = string  # invoice section id
-  })
-```
-
 ## Notes
 
 A billing account with billing profile and invoice section is required. In order to create the subscription, the user running Terraform needs
-'Azure Subscription Creator' or one of the billing (profile) roles, see also: https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/understand-mca-roles#subscription-billing-roles-and-tasks 
+'Azure Subscription Creator' or one of the billing (profile) roles, see also: https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/understand-mca-roles#subscription-billing-roles-and-tasks
 
-Even though the properties are called billing account name, billing profile name and invoice section name in Terraform, in the portal this is called the billing profile ID, billling account ID and invoice section ID. 
+Even though the properties are called billing account name, billing profile name and invoice section name in Terraform, in the portal this is called the billing profile ID, billling account ID and invoice section ID.


### PR DESCRIPTION
## Description

This PR generated the documentation in the document style and included the type definitions.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)